### PR TITLE
Update GHA workflow for import into ReD

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Checkmarx One CLI Action
-         uses: checkmarx/ast-github-action@2.3.36 # Github Action version
+        uses: checkmarx/ast-github-action@2.3.36 # Github Action version
         with:
           project_name: ${{ secrets.PROJECT_NAME }}
           cx_tenant: ${{ secrets.CX_TENANT }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Checkmarx One CLI Action
-        uses: checkmarx/ast-github-action@main #Github Action version
+         uses: checkmarx/ast-github-action@2.3.36 # Github Action version
         with:
           project_name: ${{ secrets.PROJECT_NAME }}
           cx_tenant: ${{ secrets.CX_TENANT }}


### PR DESCRIPTION
Checkmarx GHA needed update to a specific, locked version in order for it to work. This change (along with updating the secret) should allow the code imports into ReD to function once again.